### PR TITLE
Typed query results

### DIFF
--- a/assets/scripts/breakout.ts
+++ b/assets/scripts/breakout.ts
@@ -1,12 +1,3 @@
-function filterComponentInfos(
-  infos: ComponentInfo[],
-  prefix: string
-): string[] {
-  return infos
-    .filter((info) => info.name.startsWith(prefix))
-    .map((info) => info.name.replace(prefix, ""));
-}
-
 let firstIteration = true;
 let i = 0;
 
@@ -14,6 +5,11 @@ type Scoreboard = {
   score: number;
 };
 const Scoreboard: BevyType<Scoreboard> = { typeName: "breakout::Scoreboard" };
+
+type Velocity = {
+  0: { x: number, y: number; },
+};
+const Velocity: BevyType<Velocity> = { typeName: "breakout::Velocity" };
 
 function run() {
   i++;
@@ -25,8 +21,11 @@ function run() {
 
   if (firstIteration) {
     firstIteration = false;
-    // info("Components: " + filterComponentInfos(world.components, "bevy_transform::"));
-    // info("Resources: " + filterComponentInfos(world.resources, "breakout::").join(", "));
+
+    for (const item of world.query(Velocity)) {
+      let [velocity] = item.components;
+      info("Velocity:", velocity[0].toString());
+    }
   }
 }
 

--- a/lib.bevy.d.ts
+++ b/lib.bevy.d.ts
@@ -38,11 +38,6 @@ type QueryDescriptor = {
   components: ComponentId[];
 };
 
-type QueryItem = {
-  entity: Entity;
-  components: any[];
-};
-
 type Primitive = number | string | boolean;
 interface Value {
   [path: string | number]: Value | Primitive | undefined;
@@ -50,6 +45,18 @@ interface Value {
 
 type BevyType<T> = {
   typeName: string;
+};
+
+
+type ExtractBevyType<T> = T extends BevyType<infer U> ? U
+  : T extends ComponentId ? Value
+  : never;
+type MapQueryArgs<Q> = { [C in keyof Q]: ExtractBevyType<Q[C]> };
+
+type QueryParameter = BevyType<unknown> | ComponentId;
+type QueryItem<Q> = {
+  entity: Entity;
+  components: MapQueryArgs<Q>,
 };
 
 declare class World {
@@ -60,7 +67,7 @@ declare class World {
   resource(componentId: ComponentId): Value | null;
   resource<T>(type: BevyType<T>): T | null;
 
-  query(descriptor: QueryDescriptor): QueryItem[];
+  query<Q extends QueryParameter[]>(...query: Q): QueryItem<Q>[];
 }
 
 declare let world: World;

--- a/src/runtime/ops/ecs/ecs.js
+++ b/src/runtime/ops/ecs/ecs.js
@@ -84,11 +84,10 @@
                                 target.valueRef
                             );
                     default:
-                        const isInt = !isNaN(parseInt(p));
                         let valueRef = bevyModJsScriptingOpSync(
                             "ecs_value_ref_get",
                             target.valueRef,
-                            isInt ? `[${p}]` : "." + p
+                            p,
                         );
                         return wrapValueRef(valueRef);
                 }
@@ -97,7 +96,7 @@
                 bevyModJsScriptingOpSync(
                     "ecs_value_ref_set",
                     target.valueRef,
-                    "." + p,
+                    p,
                     value
                 );
             },

--- a/src/runtime/ops/ecs/ecs.js
+++ b/src/runtime/ops/ecs/ecs.js
@@ -36,14 +36,13 @@
             return resource != null ? wrapValueRef(resource) : null;
         }
 
-        query(descriptor) {
+        query(...parameters) {
             return bevyModJsScriptingOpSync(
                 "ecs_world_query",
-                descriptor
+                parameters,
             ).map(({ entity, components }) => ({
                 entity,
                 components: components.map(wrapValueRef),
-                test: components,
             }));
         }
     }

--- a/src/runtime/ops/ecs/query.rs
+++ b/src/runtime/ops/ecs/query.rs
@@ -4,7 +4,9 @@ use bevy_ecs_dynamic::reflect_value_ref::{query::EcsValueRefQuery, ReflectValueR
 
 use crate::runtime::OpContext;
 
-use super::types::{JsQueryItem, JsValueRef, JsValueRefs, QueryDescriptor};
+use super::types::{ComponentIdOrBevyType, JsQueryItem, JsValueRef, JsValueRefs};
+
+pub type QueryDescriptor = Vec<ComponentIdOrBevyType>;
 
 pub fn ecs_world_query(
     context: OpContext,
@@ -20,10 +22,9 @@ pub fn ecs_world_query(
         serde_json::from_value(args).context("Parse world query descriptor")?;
 
     let components: Vec<ComponentId> = descriptor
-        .components
         .iter()
-        .map(ComponentId::from)
-        .collect();
+        .map(|ty| ty.component_id(world))
+        .collect::<Result<_, _>>()?;
 
     let mut query = EcsValueRefQuery::new(world, &components);
     let results = query

--- a/src/runtime/ops/ecs/types.rs
+++ b/src/runtime/ops/ecs/types.rs
@@ -46,9 +46,9 @@ pub enum ComponentIdOrBevyType {
 }
 
 impl ComponentIdOrBevyType {
-    pub fn component_id(self, world: &World) -> Result<ComponentId, anyhow::Error> {
+    pub fn component_id(&self, world: &World) -> Result<ComponentId, anyhow::Error> {
         match self {
-            ComponentIdOrBevyType::ComponentId(id) => Ok(ComponentId::from(&id)),
+            ComponentIdOrBevyType::ComponentId(id) => Ok(ComponentId::from(id)),
             ComponentIdOrBevyType::Type { type_name } => {
                 let type_registry = world.resource::<TypeRegistryArc>().read();
                 let registration = type_registry.get_with_name(&type_name).ok_or_else(|| {
@@ -111,11 +111,6 @@ impl From<Entity> for JsEntity {
             generation: entity.generation(),
         }
     }
-}
-
-#[derive(Deserialize)]
-pub struct QueryDescriptor {
-    pub components: Vec<JsComponentId>,
 }
 
 // Value, from which a `ReflectArg` can be borrowed


### PR DESCRIPTION
```ts
type Transform = {
  translation: unknown,,
  rotation: unknown,
  scale: unknown,
};
const Transform: BevyType<Transform> = { typeName: "bevy_transform::components::transform::Transform" };

type Velocity = {
  0: unknown,
};
const Velocity: BevyType<Velocity> = { typeName: "breakout::Velocity" };

let results = world.query(Transform, Velocity, some_component_id);
```
will now infer `results` to be of type `{ entity: Entity, components: [Velocity, Transform, Value] }[]`.

Also fixes `tuple_struct.0` to use `.0` reflect path instead of `[0]`.