### PR TITLE
Add world.spawn()

### DIFF
--- a/src/runtime/ops/ecs.rs
+++ b/src/runtime/ops/ecs.rs
@@ -4,12 +4,12 @@ use crate::runtime::{JsRuntimeOp, OpMap};
 
 use self::types::{JsReflectFunctions, JsValueRefs};
 
-mod component;
 mod info;
 mod query;
 mod resource;
 pub mod types;
 mod value;
+mod world;
 
 pub fn insert_ecs_ops(ops: &mut OpMap) {
     ops.insert("ecs_js", Box::new(EcsJs));
@@ -41,9 +41,10 @@ pub fn insert_ecs_ops(ops: &mut OpMap) {
         Box::new(value::ecs_value_ref_default),
     );
     ops.insert("ecs_value_ref_patch", Box::new(value::ecs_value_ref_patch));
+    ops.insert("ecs_entity_spawn", Box::new(world::ecs_entity_spawn));
     ops.insert(
         "ecs_component_insert",
-        Box::new(component::ecs_component_insert),
+        Box::new(world::ecs_component_insert),
     );
 }
 

--- a/src/runtime/ops/ecs/ecs.js
+++ b/src/runtime/ops/ecs/ecs.js
@@ -97,6 +97,10 @@
                 Value.unwrapValueRef(component)
             );
         }
+
+        spawn() {
+            return Value.wrapValueRef(bevyModJsScriptingOpSync("ecs_entity_spawn"));
+        }
     }
 
     const valueRefFinalizationRegistry = new FinalizationRegistry(ref => {

--- a/src/runtime/ops/ecs/world.rs
+++ b/src/runtime/ops/ecs/world.rs
@@ -4,6 +4,22 @@ use bevy_reflect::TypeRegistryArc;
 
 use crate::{JsValueRef, JsValueRefs, OpContext};
 
+pub fn ecs_entity_spawn(
+    context: OpContext,
+    world: &mut bevy::prelude::World,
+    _args: serde_json::Value,
+) -> anyhow::Result<serde_json::Value> {
+    let value_refs = context
+        .op_state
+        .entry::<JsValueRefs>()
+        .or_insert_with(default);
+
+    let entity = world.spawn().id();
+    let value_ref = JsValueRef::new_free(Box::new(entity), value_refs);
+
+    Ok(serde_json::to_value(value_ref)?)
+}
+
 pub fn ecs_component_insert(
     context: OpContext,
     world: &mut bevy::prelude::World,

--- a/types/lib.bevy.d.ts
+++ b/types/lib.bevy.d.ts
@@ -80,6 +80,7 @@ declare class World {
   query<Q extends QueryParameter[]>(...query: Q): QueryItems<Q>;
   get<T>(entity: Entity, component: BevyType<T>): T | undefined;
   insert(entity: Entity, component: any): void;
+  spawn(): Entity;
 }
 
 declare let world: World;


### PR DESCRIPTION
I was almost able to spawn the breakout ball with the script, but we can't have reflected bundles yet, and when trying to add the components one by one we were missing reflected Default implementations on `ComputedVisiblity` and `Sprite`, and I'm not sure how to go about creating a typed `Handle<T>` from scratch in a script. :/

It seems like reflected bundles might be the best way to go about spawning things like sprites. If the bundle implemented Reflect then you could just set/patch the fields you wanted to modify on the default bundle, so we wouldn't have to worry about creating a `Handle<T>`, because we can just set the Handle.id from the script.