### PR TITLE
`World.spawn()`, Non-primitive Assignments, and Patching

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod transpile;
 use asset::JsScriptLoader;
 use bevy::{asset::AssetStage, prelude::*, utils::HashSet};
 
+pub use bevy_reflect_fns;
 pub use asset::JsScript;
 pub use bevy_ecs_dynamic;
 pub use runtime::{

--- a/src/runtime/native.rs
+++ b/src/runtime/native.rs
@@ -285,6 +285,7 @@ fn op_bevy_mod_js_scripting(
     args: serde_json::Value,
 ) -> Result<serde_json::Value, AnyError> {
     with_state(state, |state, custom_op_state| {
+        let args = convert_safe_ints(args);
         let script_info = state.borrow::<ScriptInfo>();
         let ops = state.borrow::<Ops>();
         let op_names = state.borrow::<OpNames>();
@@ -322,4 +323,47 @@ fn with_state<T: 'static, R, F: FnOnce(&mut OpState, &mut T) -> R>(state: &mut O
     state.put(t);
 
     r
+}
+
+/// Takes a [`serde_json::Value`] and converts all floating point number types that are safe
+/// integers, to integers.
+///
+/// This is important for deserializing numbers to integers, because of the way `serde_json` handles
+/// them.
+///
+/// For example, `serde_json` will not deserialize `1.0` to a `u32` without an error, but it will
+/// deserialize `1`. `serde_v8` seems to retun numbers with a decimal point, even when they are
+/// valid integers, so this function makes the conversion of safe integers back to integers without
+/// a decimal point.
+fn convert_safe_ints(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Number(n) => {
+            let max_safe_int = (2u64.pow(53) - 1) as f64;
+
+            serde_json::Value::Number(if let Some(f) = n.as_f64() {
+                if f.abs() <= max_safe_int && f.fract() == 0.0 {
+                    if f == 0.0 {
+                        serde_json::Number::from(0u64)
+                    } else if f.is_sign_negative() {
+                        serde_json::Number::from(f as i64)
+                    } else {
+                        serde_json::Number::from(f as u64)
+                    }
+                } else {
+                    n
+                }
+            } else {
+                n
+            })
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(|x| convert_safe_ints(x)).collect())
+        }
+        serde_json::Value::Object(obj) => serde_json::Value::Object(
+            obj.into_iter()
+                .map(|(k, v)| (k, convert_safe_ints(v)))
+                .collect(),
+        ),
+        other => other,
+    }
 }

--- a/src/runtime/ops/ecs.rs
+++ b/src/runtime/ops/ecs.rs
@@ -40,6 +40,7 @@ pub fn insert_ecs_ops(ops: &mut OpMap) {
         Box::new(value::ecs_value_ref_default),
     );
     ops.insert("ecs_value_ref_patch", Box::new(value::ecs_value_ref_patch));
+    ops.insert("ecs_value_ref_cleanup", Box::new(value::EcsValueRefCleanup));
     ops.insert("ecs_entity_spawn", Box::new(world::ecs_entity_spawn));
     ops.insert("ecs_value_ref_cleanup", Box::new(value::EcsValueRefCleanup));
     ops.insert(

--- a/src/runtime/ops/ecs.rs
+++ b/src/runtime/ops/ecs.rs
@@ -4,12 +4,12 @@ use crate::runtime::{JsRuntimeOp, OpMap};
 
 use self::types::{JsReflectFunctions, JsValueRefs};
 
-mod component;
 mod info;
 mod query;
 mod resource;
 pub mod types;
 mod value;
+mod world;
 
 pub fn insert_ecs_ops(ops: &mut OpMap) {
     ops.insert("ecs_js", Box::new(EcsJs));
@@ -40,10 +40,11 @@ pub fn insert_ecs_ops(ops: &mut OpMap) {
         Box::new(value::ecs_value_ref_default),
     );
     ops.insert("ecs_value_ref_patch", Box::new(value::ecs_value_ref_patch));
+    ops.insert("ecs_entity_spawn", Box::new(world::ecs_entity_spawn));
     ops.insert("ecs_value_ref_cleanup", Box::new(value::EcsValueRefCleanup));
     ops.insert(
         "ecs_component_insert",
-        Box::new(component::ecs_component_insert),
+        Box::new(world::ecs_component_insert),
     );
 }
 

--- a/src/runtime/ops/ecs/ecs.js
+++ b/src/runtime/ops/ecs/ecs.js
@@ -164,7 +164,7 @@
                         "ecs_value_ref_set",
                         target.valueRef,
                         p,
-                        value
+                        Value.unwrapValueRef(value)
                     );
                 },
                 apply: (target, thisArg, args) => {

--- a/src/runtime/ops/ecs/ecs.js
+++ b/src/runtime/ops/ecs/ecs.js
@@ -79,7 +79,7 @@
                         default:
                             const collected = collectedQuery(target);
                             const prop = collected[propName];
-                            return prop.bind ? prop.bind(collected) : prop;
+                            return prop && prop.bind ? prop.bind(collected) : prop;
                     }
                 }
             })

--- a/src/runtime/ops/ecs/ecs.js
+++ b/src/runtime/ops/ecs/ecs.js
@@ -97,6 +97,10 @@
                 Value.unwrapValueRef(component)
             );
         }
+
+        spawn() {
+            return Value.wrapValueRef(bevyModJsScriptingOpSync("ecs_entity_spawn"));
+        }
     }
 
     const VALUE_REF_GET_INNER = Symbol("value_ref_get_inner");

--- a/src/runtime/ops/ecs/ecs.js
+++ b/src/runtime/ops/ecs/ecs.js
@@ -110,7 +110,16 @@
         unwrapValueRef(valueRefProxy) {
             if (valueRefProxy === null || valueRefProxy === undefined) return valueRefProxy;
             const inner = valueRefProxy[VALUE_REF_GET_INNER]
-            return inner ? inner : valueRefProxy;
+            if (inner) {
+                return inner;
+            } else {
+                if (typeof valueRefProxy == 'object') {
+                    for (const key of Reflect.ownKeys(valueRefProxy)) {
+                        valueRefProxy[key] = Value.unwrapValueRef(valueRefProxy[key]);
+                    }
+                }
+                return valueRefProxy;
+            }
         },
 
         // keep primitives, null and undefined as is, otherwise wraps the object
@@ -183,7 +192,7 @@
 
         // Instantiates the default value of a given bevy type
         create(type, patch) {
-            return Value.wrapValueRef(bevyModJsScriptingOpSync("ecs_value_ref_default", type.typeName, patch));
+            return Value.wrapValueRef(bevyModJsScriptingOpSync("ecs_value_ref_default", type.typeName, Value.unwrapValueRef(patch)));
         },
 
         patch(value, patch) {

--- a/src/runtime/ops/ecs/value.rs
+++ b/src/runtime/ops/ecs/value.rs
@@ -9,7 +9,7 @@ use bevy_ecs_dynamic::reflect_value_ref::ReflectValueRef;
 use bevy_reflect::{Reflect, ReflectRef, TypeRegistryArc};
 use bevy_reflect_fns::{PassMode, ReflectArg, ReflectMethods};
 
-use crate::runtime::OpContext;
+use crate::{runtime::OpContext, JsRuntimeOp, JsReflectFunctions};
 
 use super::{
     types::{

--- a/src/runtime/ops/ecs/value.rs
+++ b/src/runtime/ops/ecs/value.rs
@@ -36,7 +36,7 @@ macro_rules! try_downcast_leaf_set {
                 return Ok(());
             })*
 
-            Ok::<(), anyhow::Error>(())
+            bail!("Couldn't assign to primitive");
         })()
     };
 }
@@ -60,7 +60,7 @@ pub fn patch_reflect_with_json(
             )?;
         }
         serde_json::Value::Array(array) => match value.reflect_mut() {
-            bevy_reflect::ReflectMut::Struct(_) => todo!(),
+            bevy_reflect::ReflectMut::Struct(_) => bail!("Cannot patch struct with Array"),
             bevy_reflect::ReflectMut::List(target) => {
                 let target_len = target.len();
                 let patch_len = array.len();
@@ -150,6 +150,53 @@ pub fn patch_reflect_with_json(
     }
 
     Ok(())
+}
+
+/// Check whether or not it's safe to `Reflect.apply` one reflect to another
+fn reflect_is_compatible(reflect1: &dyn Reflect, reflect2: &dyn Reflect) -> bool {
+    match (reflect1.reflect_ref(), reflect2.reflect_ref()) {
+        (ReflectRef::Value(value1), ReflectRef::Value(value2)) => {
+            value1.type_id() == value2.type_id()
+        }
+        (ReflectRef::Array(arr1), ReflectRef::Array(arr2)) => {
+            arr1.iter()
+                .zip(arr2.iter())
+                .fold(true, |compatible, (reflect1, reflect2)| {
+                    compatible && reflect_is_compatible(reflect1, reflect2)
+                })
+        }
+        (ReflectRef::List(list1), ReflectRef::List(list2)) => {
+            list1
+                .iter()
+                .zip(list2.iter())
+                .fold(true, |compatible, (reflect1, reflect2)| {
+                    compatible && reflect_is_compatible(reflect1, reflect2)
+                })
+        }
+        (ReflectRef::Tuple(tuple1), ReflectRef::Tuple(tuple2)) => tuple1
+            .iter_fields()
+            .zip(tuple2.iter_fields())
+            .fold(true, |compatible, (reflect1, reflect2)| {
+                compatible && reflect_is_compatible(reflect1, reflect2)
+            }),
+        (ReflectRef::TupleStruct(tuple1), ReflectRef::TupleStruct(tuple2)) => tuple1
+            .iter_fields()
+            .zip(tuple2.iter_fields())
+            .fold(true, |compatible, (reflect1, reflect2)| {
+                compatible && reflect_is_compatible(reflect1, reflect2)
+            }),
+        (ReflectRef::Struct(struct1), ReflectRef::Struct(struct2)) => struct1
+            .iter_fields()
+            .enumerate()
+            .fold(true, |compatible, (i, field1)| {
+                if let Some(field2) = struct2.field(struct1.name_at(i).unwrap()) {
+                    compatible && reflect_is_compatible(field1, field2)
+                } else {
+                    compatible
+                }
+            }),
+        _ => false,
+    }
 }
 
 pub fn ecs_value_ref_get(
@@ -244,22 +291,53 @@ pub fn ecs_value_ref_set(
     // Access the provided path on the value ref
     let mut value_ref = append_path(value_ref, path, world)?;
 
-    // Get the reflect value
-    let mut reflect = value_ref.get_mut(world).unwrap();
+    // Try to asign as a primitive
+    let primitive_assignment_result = {
+        let new_value = new_value.clone();
+        let mut reflect = value_ref.get_mut(world)?;
 
-    // Try to store a primitive in the value
-    try_downcast_leaf_set!(reflect <- new_value for
-        u8, u16, u32, u64, u128, usize,
-        i8, i16, i32, i64, i128, isize,
-        String, char, bool, f32, f64
-    )
-    .map(|_| serde_json::Value::Null)
-    .map_err(|e| {
-        format_err!(
-            "could not set value reference: type `{typename}` is not a primitive type: {e}",
-            typename = reflect.type_name(),
+        // Try to store a primitive in the value
+        try_downcast_leaf_set!(reflect <- new_value for
+            u8, u16, u32, u64, u128, usize,
+            i8, i16, i32, i64, i128, isize,
+            String, char, bool, f32, f64
         )
-    })
+        .map_err(|e| {
+            format_err!(
+                "could not set value reference: type `{type_name}` is not a primitive \
+                type or value ref: {e}",
+                type_name = reflect.type_name(),
+            )
+        })
+    };
+
+    // If we could not assign a primitive
+    if let Err(e) = primitive_assignment_result {
+        // Try to assign as a reflect value
+        if let Ok(new_js_value_ref) = serde_json::from_value::<JsValueRef>(new_value) {
+            let new_value_ref = value_refs
+                .get(new_js_value_ref.key)
+                .ok_or_else(|| format_err!("Value ref doesn't exist"))?;
+            let new_reflect = new_value_ref.get(world)?.clone_value();
+            let mut reflect = value_ref.get_mut(world)?;
+
+            if !reflect_is_compatible(new_reflect.as_reflect(), reflect.as_reflect()) {
+                bail!(
+                    "Cannot assign value ref. {} cannot be assigned to {}",
+                    new_reflect.type_name(),
+                    reflect.type_name()
+                );
+            }
+
+            reflect.apply(new_reflect.as_reflect());
+
+            Ok(serde_json::Value::Null)
+        } else {
+            Err(e)
+        }
+    } else {
+        Ok(serde_json::Value::Null)
+    }
 }
 
 pub fn ecs_value_ref_keys(
@@ -558,4 +636,63 @@ fn append_path(
         ReflectRef::Map(_) | ReflectRef::Value(_) => path,
     };
     Ok(value_ref.append_path(&path, world)?)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(Reflect, Default)]
+    struct S1 {
+        a: String,
+        b: f32,
+    }
+
+    #[derive(Reflect, Default)]
+    struct S2 {
+        a: String,
+        b: f32,
+        c: u32,
+    }
+
+    #[derive(Reflect, Default)]
+    struct S3 {
+        a: String,
+        b: u32,
+    }
+
+    #[test]
+    fn test_reflect_is_compatible_check() {
+        let string = Box::new(String::default()) as Box<dyn Reflect>;
+        let uint = Box::new(0u32) as Box<dyn Reflect>;
+        let mut s1 = Box::new(S1::default()) as Box<dyn Reflect>;
+        let s2 = Box::new(S2::default()) as Box<dyn Reflect>;
+        let s3 = Box::new(S3::default()) as Box<dyn Reflect>;
+
+        assert!(!reflect_is_compatible(
+            uint.as_reflect(),
+            string.as_reflect()
+        ));
+        assert!(!reflect_is_compatible(s1.as_reflect(), string.as_reflect()));
+
+        assert!(reflect_is_compatible(s1.as_reflect(), s2.as_reflect()));
+        s1.apply(s2.as_reflect());
+
+        assert!(!reflect_is_compatible(s1.as_reflect(), s3.as_reflect()));
+
+        let mut l1 = Box::new(vec![1, 2, 3]) as Box<dyn Reflect>;
+        let l2 = Box::new(vec![5, 4, 3, 2, 1]) as Box<dyn Reflect>;
+
+        assert!(reflect_is_compatible(l1.as_reflect(), l2.as_reflect()));
+        l1.apply(l2.as_reflect());
+        assert!(!reflect_is_compatible(l1.as_reflect(), s1.as_reflect()));
+
+        let mut t1 = Box::new((0u32, String::from("hi"))) as Box<dyn Reflect>;
+        let t2 = Box::new((1u32, String::from("bye"))) as Box<dyn Reflect>;
+        let t3 = Box::new((0f32, String::from("bye"))) as Box<dyn Reflect>;
+
+        assert!(reflect_is_compatible(t1.as_reflect(), t2.as_reflect()));
+        t1.apply(t2.as_reflect());
+        assert!(!reflect_is_compatible(t1.as_reflect(), t3.as_reflect()));
+    }
 }

--- a/src/runtime/ops/ecs/world.rs
+++ b/src/runtime/ops/ecs/world.rs
@@ -4,6 +4,22 @@ use bevy_reflect::TypeRegistryArc;
 
 use crate::{JsValueRef, JsValueRefs, OpContext};
 
+pub fn ecs_entity_spawn(
+    context: OpContext,
+    world: &mut bevy::prelude::World,
+    _args: serde_json::Value,
+) -> anyhow::Result<serde_json::Value> {
+    let value_refs = context
+        .op_state
+        .entry::<JsValueRefs>()
+        .or_insert_with(default);
+
+    let entity = world.spawn().id();
+    let value_ref = JsValueRef::new_free(Box::new(entity), value_refs);
+
+    Ok(serde_json::to_value(value_ref)?)
+}
+
 pub fn ecs_component_insert(
     context: OpContext,
     world: &mut bevy::prelude::World,

--- a/types/lib.bevy.d.ts
+++ b/types/lib.bevy.d.ts
@@ -22,9 +22,13 @@ declare interface BevyScript {
 
 declare type RawValueRef = unknown;
 
+type RecursivePartial<T> = {
+    [P in keyof T]?: RecursivePartial<T[P]>;
+};
+
 declare interface ValueGlobal {
-  create<T>(t: BevyType<T>, patch?: any): T;
-  patch<T>(value: any, patch: any): T;
+  create<T>(t: BevyType<T>, patch?: RecursivePartial<T>): T;
+  patch<T>(value: T, patch: RecursivePartial<T>): T;
 }
 
 declare let Value: ValueGlobal;

--- a/types/lib.bevy.d.ts
+++ b/types/lib.bevy.d.ts
@@ -80,6 +80,7 @@ declare class World {
   query<Q extends QueryParameter[]>(...query: Q): QueryItems<Q>;
   get<T>(entity: Entity, component: BevyType<T>): T | undefined;
   insert(entity: Entity, component: any): void;
+  spawn(): Entity;
 }
 
 declare let world: World;


### PR DESCRIPTION
This PR

1. Adds a simple `world.spawn()` method.
1. Allows you to assign non-primitives to value refs, allowing, in my use case, me to set the `id` of a `Handle<T>` in Bevy even though `HandleId` is not a JS primitive.
2. Fixes a bug I introduced with the `Value.patch()` PR where non-primitive assignments stopped throwing an error when they failed.

It's worth noting that non-primitive patching doesn't work yet. That will require a kind of recursive value ref unwrapping helper, which I haven't implemented yet.