### PR TITLE
add input reading to breakout example

### DIFF
--- a/assets/scripts/breakout.ts
+++ b/assets/scripts/breakout.ts
@@ -14,6 +14,19 @@ const Velocity: BevyType<Velocity> = { typeName: "breakout::Velocity" };
 type Ball = unknown;
 const Ball: BevyType<Ball> = { typeName: "breakout::Ball" };
 
+type KeyCode = unknown; // enum handling is not implemented
+const KeyCode: BevyType<KeyCode> = { typeName: "bevy_input::keyboard::KeyCode" };
+
+type Input<T> = {
+  pressed: (key: T) => boolean,
+  just_pressed: (key: T) => boolean,
+  press: (key: T) => void,
+  get_pressed: () => T[],
+};
+const Input: <T>(T: BevyType<T>) => BevyType<Input<T>> = (T) => ({
+  typeName: `bevy_input::input::Input<${T.typeName}>`,
+});
+
 function run() {
   i++;
   if (i % 60 == 0) {
@@ -22,15 +35,20 @@ function run() {
     info(score.score);
   }
 
+  let input = world.resource(Input(KeyCode))!;
+  let pressed = input.get_pressed();
+  info(pressed.toString());
+
+
   if (firstIteration) {
     firstIteration = false;
 
-    for (const item of world.query(Transform, Velocity)) {
+    /*for (const item of world.query(Transform, Velocity)) {
       let [transform, velocity] = item.components;
 
       info("Velocity:", velocity[0].toString());
       info("Transform:", transform.translation.toString());
-    }
+    }*/
   }
 }
 


### PR DESCRIPTION
@zicklag pinging you for a few reasons.

1. it's super cool that this just works without any changes 

```ts
  let input = world.resource(Input(KeyCode))!;
  let pressed = input.get_pressed();
  info(pressed.toString());
```
```rust
2022-11-16T20:09:58.210348Z  INFO script{path="scripts/breakout.ts"}: js_runtime: [Space]
2022-11-16T20:09:58.226254Z  INFO script{path="scripts/breakout.ts"}: js_runtime: []
2022-11-16T20:09:58.242964Z  INFO script{path="scripts/breakout.ts"}: js_runtime: [H]
2022-11-16T20:09:58.259832Z  INFO script{path="scripts/breakout.ts"}: js_runtime: []
2022-11-16T20:09:58.276756Z  INFO script{path="scripts/breakout.ts"}: js_runtime: []
2022-11-16T20:09:58.293440Z  INFO script{path="scripts/breakout.ts"}: js_runtime: 3
```

2. I think the pattern for creating generic `BevyType`s is worth pointing out

```ts
type KeyCode = unknown;
const KeyCode: BevyType<KeyCode> = { typeName: "bevy_input::keyboard::KeyCode" };

type Input<T> = {
  pressed: (key: T) => boolean,
  just_pressed: (key: T) => boolean,
  press: (key: T) => void,
  get_pressed: () => T[],
};
const Input: <T>(T: BevyType<T>) => BevyType<Input<T>> = (T) => ({
  typeName: `bevy_input::input::Input<${T.typeName}>`,
});
```
Of course you could also just use
```ts
const InputKeyCode: BevyType<Input<KeyCode>> {
  typeName: "bevy_input::input::Input<bevy_input::keyboard::KeyCode>",
};
```
and you wouldn't rely on the fact that you can do string manipulation on type names, but `Input(KeyCode)` is a bit more flexible.


Calling `press` or `just_pressed` doesn't work yet because enum handling isn't implemented yet. 