### PR TITLE
Use IndexSet For More Deterministic Execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "bevy_reflect_fns",
  "deno_core",
  "fixedbitset",
+ "indexmap",
  "js-sys",
  "pollster",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ fixedbitset = "0.4"
 slotmap = { version = "1.0.6", features = ["serde"] }
 pollster = "0.2.5"
 type-map = "0.5.0"
+indexmap = "1.9.1"
 
 serde = "1.0"
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod runtime;
 mod transpile;
 
 use asset::JsScriptLoader;
-use bevy::{asset::AssetStage, ecs::schedule::SystemDescriptor, prelude::*, utils::HashSet};
+use bevy::{asset::AssetStage, ecs::schedule::SystemDescriptor, prelude::*};
 
 pub use asset::JsScript;
 pub use bevy_ecs_dynamic;
@@ -31,7 +31,7 @@ pub struct JsScriptingPlugin {
 }
 
 #[derive(Resource, Default, Deref, DerefMut)]
-pub struct ActiveScripts(pub HashSet<Handle<JsScript>>);
+pub struct ActiveScripts(pub indexmap::IndexSet<Handle<JsScript>, bevy::utils::FixedState>);
 
 impl Plugin for JsScriptingPlugin {
     fn build(&self, app: &mut App) {


### PR DESCRIPTION
I'm working on a game using a p2p rollback networking model that requires a deterministic execution, so having a way to make sure the JS scripts run in a consistent order is important.

If you thought it was worth the extra feature, we could hide the dependency behind a `enhanced-determinism` cargo feature, similar to Rapier and maybe eventually Bevy.