### PR TITLE
fix: make WASM backend compile again.

### DIFF
--- a/src/runtime/wasm.rs
+++ b/src/runtime/wasm.rs
@@ -43,9 +43,13 @@ impl BevyModJsScripting {
         trace!(%op_idx, ?op_name, ?args, "Executing JS OP..");
 
         if let Some(op) = ops.get(op_idx) {
+            let type_registry = world.resource::<AppTypeRegistry>().0.clone();
+            let type_registry = type_registry.read();
+
             let context = OpContext {
                 op_state,
                 script_info,
+                type_registry: &*type_registry,
             };
             let result = op
                 .run(context, world, args)


### PR DESCRIPTION
The WASM target was recently broken by adding the `type_registry` field to the `OpContext` for native builds. This simply adds the missing field for the WASM backend as well.